### PR TITLE
Fixes typo and type error

### DIFF
--- a/edge/routes/edge.json
+++ b/edge/routes/edge.json
@@ -1,6 +1,6 @@
 {
     "zone_key": "{{ variable "zone" }}",
-    "domain_key": "edge.inress.domain",
+    "domain_key": "edge.ingress.domain",
     "route_key": "edge.{{ variable "clusterName" }}.route",
     "path": "/",
     "prefix_rewrite": "",

--- a/service/listeners/egress.json
+++ b/service/listeners/egress.json
@@ -6,7 +6,7 @@
     ],
     "name": "egress",
     "ip": "localhost",
-    "port": "{{ variable "sidecarEgressPort" }}",
+    "port": {{ variable "sidecarEgressPort" }},
     "protocol": "http_auto",
     "tracing_config": null
 }

--- a/service/listeners/ingress.json
+++ b/service/listeners/ingress.json
@@ -6,7 +6,7 @@
     ],
     "name": "ingress",
     "ip": "0.0.0.0",
-    "port": "{{ variable "sidecarIngressPort" }}",
+    "port": {{ variable "sidecarIngressPort" }},
     "protocol": "http_auto",
     "secret": {
         "secret_key": "{{ variable "serviceName" }}.identity",


### PR DESCRIPTION
Closes #6 
Closes #7 

This PR corrects a spelling typo in the edge route template and a type error in the service listener template.