### PR TITLE
Add egress listener key into proxy object

### DIFF
--- a/service/proxies/{{ variable "serviceName" }}.json
+++ b/service/proxies/{{ variable "serviceName" }}.json
@@ -6,9 +6,10 @@
         "{{ variable "serviceName" }}.ingress.domain"
     ],
     "listener_keys": [
-        "{{ variable "serviceName" }}.ingress.listener"
+        "{{ variable "serviceName" }}.ingress.listener",
+        "{{ variable "serviceName" }}.egress.listener"
     ],
-    "name": "{{ variable "serviceNamespace" }}.{{ variable "serviceServiceAccount" }}",
+    "name": "{{ variable "serviceNamespace" }}.{{ variable "serviceName" }}",
     "listeners": null,
     "active_proxy_filters": [
         "gm.metrics",


### PR DESCRIPTION
Closes #10 
Service generator creates an egress listener but does not attach it to the proxy. This pr includes the missing listener key in the proxy object. Also adds the service name into the proxy name field.