### PR TITLE
Service/egress/listener IP address fix

### DIFF
--- a/service/listeners/egress.json
+++ b/service/listeners/egress.json
@@ -5,7 +5,7 @@
         "{{ variable "serviceName" }}.egress.domain"
     ],
     "name": "egress",
-    "ip": "localhost",
+    "ip": "0.0.0.0",
     "port": {{ variable "sidecarEgressPort" }},
     "protocol": "http_auto",
     "tracing_config": null


### PR DESCRIPTION
Closes #13 

Contains an update to replace localhost ip value with 0.0.0.0 for the service/egress/listener template.