### PR TITLE
Proposed change of the name key's format

### DIFF
--- a/edge/clusters/edge.json
+++ b/edge/clusters/edge.json
@@ -1,7 +1,7 @@
 {
     "zone_key": "{{ variable "zone" }}",
     "cluster_key": "edge.{{ variable "clusterName" }}.cluster",
-    "name": "{{ variable "clusterNamespace" }}.{{ variable "clusterName" }}",
+    "name": "{{ variable "clusterNamespace" }}-{{ variable "clusterName" }}",
     "instances": [],
     "circuit_breakers": null,
     "outlier_detection": null,

--- a/service/proxies/{{ variable "serviceName" }}.json
+++ b/service/proxies/{{ variable "serviceName" }}.json
@@ -9,7 +9,7 @@
         "{{ variable "serviceName" }}.ingress.listener",
         "{{ variable "serviceName" }}.egress.listener"
     ],
-    "name": "{{ variable "serviceNamespace" }}.{{ variable "serviceName" }}",
+    "name": "{{ variable "serviceNamespace" }}-{{ variable "serviceName" }}",
     "listeners": null,
     "active_proxy_filters": [
         "gm.metrics",


### PR DESCRIPTION
See #15.

The name key in the service/proxy and edge/cluster object must be tied to the `XDS_CLUSTER` of the sidecar and kubernetes container name of the service. Kubernetes does not support the period character in the container name, but does support the dash. This PR changes to format from periods to dashes.